### PR TITLE
SITES-24333 - [Importer] Support direct document upload to Sharepoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,28 @@ npm run import -- --urls tools/importer/urls.txt --importjs tools/importer/impor
 The `import.js` file you provide will be automatically bundled and sent to the Import as a Service API, so referencing
 other local scripts (such as transformers) is supported.
 
-Once complete, a pre-signed URL to download the import result (as a .zip archive) from S3 will be printed to the console. 
+Once complete, a pre-signed URL to download the import result (as a .zip archive) from S3 will be printed to the console.
+
+#### SharePoint upload
+
+Optionally, the [m365 CLI](https://pnp.github.io/cli-microsoft365/) can be installed and configured to upload the import result to SharePoint.
+You will need your `tenantId` and the `clientId` of a [Microsoft Entra application](https://pnp.github.io/cli-microsoft365/user-guide/using-own-identity/) (on your SharePoint) to setup the CLI:
+
+```
+m365 setup
+m365 login
+```
+
+Copy a link from SharePoint to the directory you'd like to upload to. This can be done from the SharePoint web UI, via the "Copy link" button.
+Your new link should take the following form: `https://example.sharepoint.com/:f:/r/sites/example/Shared%20Documents/destination-directory`
+
+Once logged in to SharePoint with the `m365` CLI, pass the SharePoint link as a param to the aem-import-helper:
+
+```
+npm run import -- --urls urls.txt --sharepointurl https://example.sharepoint.com/:f:/r/sites/example/Shared%20Documents/destination-directory
+```
+
+Once the import job is complete, the import result will be downloaded from S3, extracted, and each document will be uploaded to the specified SharePoint directory.
 
 ### Bundle
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chalk": "^5.3.0",
         "esbuild": "^0.23.0",
         "node-fetch": "^3.3.2",
+        "unzipper": "^0.12.3",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -508,6 +509,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -636,6 +642,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -695,6 +706,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/emoji-regex": {
@@ -839,6 +858,19 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -908,6 +940,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -940,8 +977,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1014,6 +1050,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1024,6 +1065,17 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/just-extend": {
@@ -1245,6 +1297,11 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1329,6 +1386,11 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1337,6 +1399,25 @@
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -1417,6 +1498,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1488,6 +1582,31 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chalk": "^5.3.0",
     "esbuild": "^0.23.0",
     "node-fetch": "^3.3.2",
+    "unzipper": "^0.12.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/src/cmd/import.js
+++ b/src/cmd/import.js
@@ -33,6 +33,10 @@ export function importCommand(yargs) {
         describe: 'path to import script',
         type: 'string'
       })
+      .option('sharepointurl', {
+        describe: 'SharePoint URL to upload imported files to',
+        type: 'string'
+      })
       .option('stage', {
         describe: 'use stage endpoint',
         type: 'boolean'
@@ -43,6 +47,7 @@ export function importCommand(yargs) {
         urls: urlsPath,
         options: optionsString,
         importjs: importJsPath,
+        sharepointurl: sharePointUploadUrl,
         stage
       } = argv;
 
@@ -67,7 +72,7 @@ export function importCommand(yargs) {
       }
 
       // Run the import job
-      runImportJobAndPoll({ urls, options, importJsPath, stage } )
+      runImportJobAndPoll({ urls, options, importJsPath, sharePointUploadUrl, stage } )
       .then(() => {
         console.log(chalk.green('Done.'));
       }).catch((error) => {

--- a/src/import/import-helper.js
+++ b/src/import/import-helper.js
@@ -74,7 +74,11 @@ async function runImportJobAndPoll( {
           console.log(chalk.green('Download the import archive:'), jobResult.downloadUrl);
           break;
         }
-        console.log(chalk.yellow('Job status:'), jobStatus.status);
+
+        const progressUrl = `${url}/progress`;
+        const jobProgress = await makeRequest(progressUrl, 'GET');
+        console.log(chalk.yellow('Job status:'), jobStatus.status, jobProgress);
+
         await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait before polling again
       } catch (error) {
         console.error(chalk.red('Error polling job status:'), error);

--- a/src/import/import-helper.js
+++ b/src/import/import-helper.js
@@ -39,6 +39,10 @@ async function runImportJobAndPoll( {
     ? 'https://spacecat.experiencecloud.live/api/ci/tools/import/jobs'
     : 'https://spacecat.experiencecloud.live/api/v1/tools/import/jobs';
 
+  function hasProvidedSharePointUrl() {
+    return typeof sharePointUploadUrl === 'string';
+  }
+
   // Function to make HTTP requests
   async function makeRequest(url, method, data) {
     const parsedUrl = new URL(url);
@@ -79,7 +83,7 @@ async function runImportJobAndPoll( {
           const jobResult = await makeRequest(`${url}/result`, 'POST');
           console.log(chalk.green('Download the import archive:'), jobResult.downloadUrl);
 
-          if (sharePointUploadUrl) {
+          if (hasProvidedSharePointUrl()) {
             // Upload the import archive to SharePoint
             await uploadZipFromS3ToSharePoint(jobResult.downloadUrl, sharePointUploadUrl);
           }

--- a/src/import/import-helper.js
+++ b/src/import/import-helper.js
@@ -67,6 +67,8 @@ async function runImportJobAndPoll( {
   async function pollJobStatus(jobId) {
     const url = `${baseURL}/${jobId}`;
     while (true) {
+      // Wait before polling
+      await new Promise((resolve) => setTimeout(resolve, 5000));
       try {
         const jobStatus = await makeRequest(url, 'GET');
         if (jobStatus.status !== 'RUNNING') {
@@ -79,7 +81,7 @@ async function runImportJobAndPoll( {
 
           if (sharePointUploadUrl) {
             // Upload the import archive to SharePoint
-            uploadZipFromS3ToSharePoint(jobResult.downloadUrl, sharePointUploadUrl);
+            await uploadZipFromS3ToSharePoint(jobResult.downloadUrl, sharePointUploadUrl);
           }
           break;
         }
@@ -87,8 +89,6 @@ async function runImportJobAndPoll( {
         const progressUrl = `${url}/progress`;
         const jobProgress = await makeRequest(progressUrl, 'GET');
         console.log(chalk.yellow('Job status:'), jobStatus.status, jobProgress);
-
-        await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait before polling again
       } catch (error) {
         console.error(chalk.red('Error polling job status:'), error);
         break;

--- a/src/import/sharepoint-uploader.js
+++ b/src/import/sharepoint-uploader.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import chalk from 'chalk';
+import unzipper from 'unzipper';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { Readable } from 'node:stream';
+
+// Temporary directory to store the extracted files
+const downloadDirDefault = `extracted-files-${Date.now()}`;
+
+async function downloadAndExtractZip(s3PresignedUrl, downloadDir) {
+  try {
+    // Download the ZIP file using fetch
+    const response = await fetch(s3PresignedUrl);
+
+    if (!response.ok) {
+      throw new Error(`Failed to download ZIP file: ${response.statusText}`);
+    }
+
+    // Extract the ZIP file to the provided directory
+    await Readable.fromWeb(response.body).pipe(unzipper.Extract({ path: downloadDir })).promise();
+    console.log('Download and extraction complete.');
+  } catch (error) {
+    console.error('Error downloading or extracting the ZIP:', error);
+    throw error;
+  }
+}
+
+function parseSharePointFolderPath(sharepointUrl) {
+  // Parse the URL
+  const urlObj = new URL(sharepointUrl);
+
+  // Extract the pathname (everything after the domain)
+  const fullPath = urlObj.pathname;
+
+  // Remove the "/:f:/r" part, which is specific to this type of SharePoint URL
+  const cleanedPath = fullPath.replace(/^\/:f:\/r/, '');
+
+  // The expected SharePoint folder path format should not have URL-encoded characters (like %20 for spaces)
+  const decodedPath = decodeURIComponent(cleanedPath);
+
+  return decodedPath;
+}
+
+function parseSharePointUrl(sharepointUrl) {
+  // Parse the URL using the URL object
+  const urlObj = new URL(sharepointUrl);
+
+  // Extract the pathname (everything after the domain)
+  const fullPathDecoded = decodeURIComponent(urlObj.pathname);
+
+  // Find the position of "/sites/" and extract the site part
+  const siteMatch = fullPathDecoded.match(/\/sites\/[^\/]+/);
+  if (!siteMatch) {
+    throw new Error('Invalid SharePoint URL: Missing "/sites/" in the URL');
+  }
+
+  const siteUrl = `${urlObj.origin}${siteMatch[0]}`;
+
+  // Extract the path after the siteUrl
+  const path = fullPathDecoded.replace(siteMatch[0], '');
+
+  // If there is a "/:f:/r" in the path, remove it
+  const cleanedPath = path.replace(/^\/:f:\/r/, '');
+
+  // Return the site URL and path as an object
+  return {
+    siteUrl,
+    basePath: cleanedPath
+  };
+}
+
+export async function uploadZipFromS3ToSharePoint(s3PresignedUrl, sharePointUrl) {
+
+  async function uploadFileToSharePoint(filePath, relativeFolder) {
+    try {
+      const fileName = path.basename(filePath);
+      const { siteUrl, basePath } = parseSharePointUrl(sharePointUrl);
+      const command = `m365 spo file add --webUrl ${siteUrl} --folder "${basePath}/${relativeFolder}" --path "${filePath}" --overwrite`;
+
+      // Execute the m365 CLI command to upload the file
+      console.log(command);
+      //execSync(command, { stdio: 'inherit' });
+
+      console.log(`File uploaded: ${fileName} to ${relativeFolder}`);
+    } catch (error) {
+      console.error('Error uploading file to SharePoint:', error);
+    }
+  }
+
+  async function uploadDirectoryToSharePoint(dirPath, rootFolder = '') {
+    const files = fs.readdirSync(dirPath);
+
+    for (const file of files) {
+      const fullPath = path.join(dirPath, file);
+      const relativePath = path.join(rootFolder, file);
+
+      if (fs.lstatSync(fullPath).isDirectory()) {
+        // Recursively upload files in subdirectories
+        await uploadDirectoryToSharePoint(fullPath, relativePath);
+      } else {
+        // Upload individual file
+        await uploadFileToSharePoint(fullPath, rootFolder);
+      }
+    }
+  }
+
+  console.log(chalk.green(`Starting upload to Sharepoint, since you provided a SharePoint URL (${sharePointUrl})`));
+  console.log(chalk.green('Downloading job archive...'));
+
+  try {
+    // Step 1: Download and extract the ZIP file
+    await downloadAndExtractZip(s3PresignedUrl, downloadDirDefault);
+
+    // Step 2: Upload files to SharePoint, preserving the directory structure
+    await uploadDirectoryToSharePoint(path.join(downloadDirDefault, 'docx'));
+
+    console.log('All files uploaded to SharePoint.');
+  } catch (error) {
+    console.error('Error processing ZIP from S3:', error);
+  }
+
+}

--- a/src/import/sharepoint-uploader.js
+++ b/src/import/sharepoint-uploader.js
@@ -17,7 +17,7 @@ import { Readable } from 'node:stream';
 import unzipper from 'unzipper';
 import chalk from 'chalk';
 
-// Maximum number of times to try uploading a file to SharePoint
+// Maximum number of times to retry uploading a file to SharePoint
 const UPLOAD_RETRY_LIMIT = 2;
 
 // Temporary directory to store the extracted files
@@ -76,8 +76,14 @@ function parseSharePointUrl(sharepointUrl) {
   };
 }
 
+/**
+ * Download a .zip file from a given S3 presigned URL and upload its contents to a SharePoint site.
+ * Includes a basic retry mechanism which will re-attempt to upload a file up to UPLOAD_RETRY_LIMIT times.
+ * @param {string} s3PresignedUrl - The S3 presigned URL to download the ZIP file from
+ * @param {string} sharePointUrl - The SharePoint URL to upload the extracted files to
+ * @returns {Promise<void>}
+ */
 export async function uploadZipFromS3ToSharePoint(s3PresignedUrl, sharePointUrl) {
-
   const successfulUploads = [];
   const failedUploads = [];
 
@@ -127,7 +133,7 @@ export async function uploadZipFromS3ToSharePoint(s3PresignedUrl, sharePointUrl)
     }
   }
 
-  console.log(chalk.green(`Starting upload to Sharepoint, since you provided a SharePoint URL (${sharePointUrl})`));
+  console.log(chalk.green(`Starting document upload to SharePoint, since you provided a SharePoint URL (${sharePointUrl})`));
 
   try {
     // Step 1: Download and extract the ZIP file


### PR DESCRIPTION
- Adds support for the `sharepointurl` flag, which will attempt to upload the the directory indicated by the URL when provided
- Depends on the presence of the `m365` CLI, installed and with a user logged in (docs coming soon)
- Includes a basic retry mechanism which will re-attempt to upload a file up to `UPLOAD_RETRY_LIMIT` times
- Example usage:

One time setup. Will need to provide `clientId` and `tenantId`:
```
$ m365 setup
$ m365 login
```

Usage:
```
$ node src/bin.js import --urls urls.txt --sharepointurl https://example.sharepoint.com/:f:/r/sites/ExampleTeam/Shared%20Documents/Sites/ImplementationDetails.dev
```