### PR TITLE
feat: Implement standalone upload command

### DIFF
--- a/src/cmd/import.js
+++ b/src/cmd/import.js
@@ -43,7 +43,7 @@ export function importCommand(yargs) {
         type: 'boolean'
       });
     },
-    handler: (argv) => {
+    handler: async (argv) => {
       const {
         urls: urlsPath,
         options: optionsString,
@@ -69,13 +69,13 @@ export function importCommand(yargs) {
       }
 
       // Run the import job
-      runImportJobAndPoll({ urls, options, importJsPath, sharePointUploadUrl, stage } )
-      .then(() => {
+      try {
+        await runImportJobAndPoll({ urls, options, importJsPath, sharePointUploadUrl, stage } );
         console.log(chalk.green('Done.'));
-      }).catch((error) => {
+      } catch(error) {
         console.error(chalk.red(`Error: ${error.message}`));
         process.exit(1);
-      });
+      };
     }
   });
 }

--- a/src/cmd/upload.js
+++ b/src/cmd/upload.js
@@ -12,26 +12,17 @@
 
 import fs from 'fs';
 import chalk from 'chalk';
-import { runImportJobAndPoll } from '../import/import-helper.js';
+import { uploadJobResult } from '../import/import-helper.js';
 import { checkEnvironment } from '../utils/env-utils.js';
 
-export function importCommand(yargs) {
+export function uploadCommand(yargs) {
   yargs.command({
-    command: 'import',
-    describe: 'Start an import job',
+    command: 'upload',
+    describe: 'Upload the result of an import job',
     builder: (yargs) => {
       return yargs
-      .option('urls', {
-        describe: 'path to urls file',
-        type: 'string',
-        demandOption: true
-      })
-      .option('options', {
-        describe: 'options as a JSON string',
-        type: 'string'
-      })
-      .option('importjs', {
-        describe: 'path to import script',
+      .option('jobid', {
+        describe: 'ID of the job to upload',
         type: 'string'
       })
       .option('sharepointurl', {
@@ -45,31 +36,15 @@ export function importCommand(yargs) {
     },
     handler: (argv) => {
       const {
-        urls: urlsPath,
-        options: optionsString,
-        importjs: importJsPath,
+        jobid: jobId,
         sharepointurl: sharePointUploadUrl,
         stage
       } = argv;
 
       checkEnvironment(process.env);
 
-      // Read URLs from the file
-      const urls = fs.readFileSync(urlsPath, 'utf8').split('\n').filter(Boolean);
-
-      // Parse the options object
-      let options;
-      if (optionsString) {
-        try {
-          options = JSON.parse(optionsString);
-        } catch (error) {
-          console.error(chalk.red('Error: Invalid options JSON.'));
-          process.exit(1);
-        }
-      }
-
-      // Run the import job
-      runImportJobAndPoll({ urls, options, importJsPath, sharePointUploadUrl, stage } )
+      // Process the upload request
+      uploadJobResult({ jobId, sharePointUploadUrl, stage })
       .then(() => {
         console.log(chalk.green('Done.'));
       }).catch((error) => {

--- a/src/cmd/upload.js
+++ b/src/cmd/upload.js
@@ -34,7 +34,7 @@ export function uploadCommand(yargs) {
         type: 'boolean'
       });
     },
-    handler: (argv) => {
+    handler: async (argv) => {
       const {
         jobid: jobId,
         sharepointurl: sharePointUploadUrl,
@@ -44,13 +44,13 @@ export function uploadCommand(yargs) {
       checkEnvironment(process.env);
 
       // Process the upload request
-      uploadJobResult({ jobId, sharePointUploadUrl, stage })
-      .then(() => {
+      try {
+        await uploadJobResult({jobId, sharePointUploadUrl, stage});
         console.log(chalk.green('Done.'));
-      }).catch((error) => {
+      } catch (error) {
         console.error(chalk.red(`Error: ${error.message}`));
         process.exit(1);
-      });
+      }
     }
   });
 }

--- a/src/utils/env-utils.js
+++ b/src/utils/env-utils.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /*
  * Copyright 2024 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -11,24 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import yargs from 'yargs';
-import {hideBin} from 'yargs/helpers';
-import {importCommand} from './cmd/import.js';
-import {rulesCommand} from './cmd/rules.js';
-import {bundleCommand} from './cmd/bundle.js';
-import {uploadCommand} from './cmd/upload.js';
+import chalk from 'chalk';
 
-const argv = yargs(hideBin(process.argv));
-
-importCommand(argv);
-uploadCommand(argv);
-rulesCommand(argv);
-bundleCommand(argv);
-
-argv
-  .scriptName("aem-import-helper")
-  .usage('$0 <cmd> [args]')
-  .strictCommands()
-  .demandCommand(1, 'You need at least one command before moving on')
-  .help()
-  .argv;
+export function checkEnvironment(env) {
+  // Ensure required environment variable is set
+  if (typeof env.AEM_IMPORT_API_KEY !== 'string') {
+    console.error(chalk.red('Error: Ensure the AEM_IMPORT_API_KEY environment variable is set.'));
+    process.exit(1);
+  }
+}

--- a/src/utils/http-utils.js
+++ b/src/utils/http-utils.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Function to make HTTP requests
+export async function makeRequest(url, method, data) {
+  const parsedUrl = new URL(url);
+  const headers = new Headers({
+    'Content-Type': data ? 'application/json' : '',
+    'x-api-key': process.env.AEM_IMPORT_API_KEY,
+  });
+
+  // FormData requests set the multipart/form-data header (including boundary) automatically
+  if (data instanceof FormData) {
+    headers.delete('Content-Type');
+  }
+
+  const res = await fetch(parsedUrl, {
+    method,
+    headers,
+    body: data,
+  });
+
+  if (res.ok) {
+    return res.json();
+  }
+
+  const body = await res.text();
+  throw new Error(`Request failed with status code ${res.status}. `
+    + `x-error header: ${res.headers.get('x-error')}, x-invocation-id: ${res.headers.get('x-invocation-id')}, `
+    + `Body: ${body}`);
+}


### PR DESCRIPTION
We should provide a command to upload a job to a SharePoint URL, after the job has already been completed.

Usage:
```
node src/bin.js upload --jobid 237ed2dc-c699-42eb-ac66-da88622cce0e --sharepointurl https://example.sharepoint.com/sites/ExampleTeam/Shared%20Documents/Sites/example.com
```